### PR TITLE
feat: logo and icon in skill card

### DIFF
--- a/layouts/partials/cards/skill.html
+++ b/layouts/partials/cards/skill.html
@@ -12,7 +12,13 @@
 
           <img class="card-img-xs" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
         {{ end }}
+        
+        {{ if .icon }}
+        {{ $iconName := .icon }}
+        <h5 class="card-title"><span class="{{ $iconName }}"> {{ .name }}</span></h5>
+        {{ else }}
         <h5 class="card-title">{{ .name }}</h5>
+        {{ end }}
       </div>
       <div class="card-body">
         <p class="card-text">{{ .summary | markdownify }}</p>


### PR DESCRIPTION
`logo` can refer to an image path, `icon` can refer to a fontawesome description.

### Issue
skill card wants `logo`, but guide for config skills has `icon`. 

### Description
Kept `logo` to display an image path, added `icon` to refer to a fontawesome description.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->